### PR TITLE
feat(mcp): gate delete tools behind env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@ BITBUCKET_WORKSPACE=your_workspace
 
 # Optional: override for Bitbucket Server/Data Center
 # BITBUCKET_BASE_URL=https://api.bitbucket.org/2.0
+
+# Optional: enable delete_branch and delete_pr_comment (default: off). Use true, 1, yes, or on.
+# BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS=true

--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ Keep app passwords out of source control. Put them only in your MCP client’s `
 
 ### 2. Environment variables
 
-| Variable                 | Required | Description                                                                 |
-| ------------------------ | -------- | --------------------------------------------------------------------------- |
-| `BITBUCKET_USERNAME`     | Yes      | Your Bitbucket username                                                     |
-| `BITBUCKET_APP_PASSWORD` | Yes      | App password from step 1                                                    |
-| `BITBUCKET_WORKSPACE`    | Yes      | Workspace slug (from your Bitbucket URL)                                    |
-| `BITBUCKET_BASE_URL`     | No       | API base URL (default: `https://api.bitbucket.org/2.0`). Use for Server/DC. |
+| Variable                                | Required | Description                                                                                                                                                      |
+| --------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BITBUCKET_USERNAME`                    | Yes      | Your Bitbucket username                                                                                                                                          |
+| `BITBUCKET_APP_PASSWORD`                | Yes      | App password from step 1                                                                                                                                         |
+| `BITBUCKET_WORKSPACE`                   | Yes      | Workspace slug (from your Bitbucket URL)                                                                                                                         |
+| `BITBUCKET_BASE_URL`                    | No       | API base URL (default: `https://api.bitbucket.org/2.0`). Use for Server/DC.                                                                                      |
+| `BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS` | No       | Set to `true`, `1`, `yes`, or `on` to register **`delete_branch`** and **`delete_pr_comment`**. Off by default so those tools are not exposed unless you opt in. |
 
 ### 3. MCP client configuration
 
@@ -84,37 +85,37 @@ Merge the `bitbucket` block into the existing `mcpServers` object if you already
 
 ### Pull requests
 
-| Tool                      | Description                                                        |
-| ------------------------- | ------------------------------------------------------------------ |
-| `list_pull_requests`      | List PRs filtered by state (OPEN / MERGED / DECLINED / SUPERSEDED) |
-| `get_pull_request`        | Full PR details including participants and reviewers               |
-| `create_pull_request`     | Open a new PR with optional reviewers                              |
-| `update_pull_request`     | Update title, description, or reviewers                            |
-| `merge_pull_request`      | Merge using merge_commit, squash, or fast_forward                  |
-| `decline_pull_request`    | Decline a PR with an optional message                              |
-| `add_pr_comment`          | Post a Markdown comment on a PR                                    |
-| `get_diff`                | Fetch the unified diff (truncated to 8 KB)                         |
-| `list_pr_comments`        | List all comments on a PR                                          |
-| `get_pr_comment`          | Get a specific comment                                             |
-| `update_pr_comment`       | Update a comment                                                   |
-| `delete_pr_comment`       | Delete a comment                                                   |
-| `resolve_pr_comment`      | Resolve a comment thread                                           |
-| `reopen_pr_comment`       | Reopen a resolved comment thread                                   |
-| `approve_pull_request`    | Approve a PR                                                       |
-| `unapprove_pull_request`  | Remove your approval                                               |
-| `request_pr_changes`      | Request changes on a PR                                            |
-| `list_pr_statuses`        | List commit/build statuses for a PR                                |
-| `list_default_reviewers`  | List default reviewers (auto-added to new PRs)                     |
-| `get_default_reviewer`    | Get a specific default reviewer                                    |
-| `add_default_reviewer`    | Add a user as default reviewer                                     |
-| `remove_default_reviewer` | Remove a user from default reviewers                               |
+| Tool                      | Description                                                         |
+| ------------------------- | ------------------------------------------------------------------- |
+| `list_pull_requests`      | List PRs filtered by state (OPEN / MERGED / DECLINED / SUPERSEDED)  |
+| `get_pull_request`        | Full PR details including participants and reviewers                |
+| `create_pull_request`     | Open a new PR with optional reviewers                               |
+| `update_pull_request`     | Update title, description, or reviewers                             |
+| `merge_pull_request`      | Merge using merge_commit, squash, or fast_forward                   |
+| `decline_pull_request`    | Decline a PR with an optional message                               |
+| `add_pr_comment`          | Post a Markdown comment on a PR                                     |
+| `get_diff`                | Fetch the unified diff (truncated to 8 KB)                          |
+| `list_pr_comments`        | List all comments on a PR                                           |
+| `get_pr_comment`          | Get a specific comment                                              |
+| `update_pr_comment`       | Update a comment                                                    |
+| `delete_pr_comment`       | Delete a comment (requires `BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS`) |
+| `resolve_pr_comment`      | Resolve a comment thread                                            |
+| `reopen_pr_comment`       | Reopen a resolved comment thread                                    |
+| `approve_pull_request`    | Approve a PR                                                        |
+| `unapprove_pull_request`  | Remove your approval                                                |
+| `request_pr_changes`      | Request changes on a PR                                             |
+| `list_pr_statuses`        | List commit/build statuses for a PR                                 |
+| `list_default_reviewers`  | List default reviewers (auto-added to new PRs)                      |
+| `get_default_reviewer`    | Get a specific default reviewer                                     |
+| `add_default_reviewer`    | Add a user as default reviewer                                      |
+| `remove_default_reviewer` | Remove a user from default reviewers                                |
 
 ### Branches
 
-| Tool            | Description                             |
-| --------------- | --------------------------------------- |
-| `list_branches` | List branches with optional name search |
-| `delete_branch` | Delete a branch in a repository         |
+| Tool            | Description                                                        |
+| --------------- | ------------------------------------------------------------------ |
+| `list_branches` | List branches with optional name search                            |
+| `delete_branch` | Delete a branch (requires `BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS`) |
 
 ## Example prompts
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,26 @@
 import { z } from "zod";
 
-const ConfigSchema = z.object({
-  BITBUCKET_USERNAME: z.string().min(1, "BITBUCKET_USERNAME is required"),
-  BITBUCKET_APP_PASSWORD: z.string().min(1, "BITBUCKET_APP_PASSWORD is required"),
-  BITBUCKET_WORKSPACE: z.string().min(1, "BITBUCKET_WORKSPACE is required"),
-  BITBUCKET_BASE_URL: z.string().url().default("https://api.bitbucket.org/2.0"),
-});
+/** True for common affirmative env strings (case-insensitive). */
+export function parseOptionalBoolEnv(value: string | undefined): boolean {
+  if (value === undefined || value === "") return false;
+  return ["1", "true", "yes", "on"].includes(value.trim().toLowerCase());
+}
+
+const ConfigSchema = z
+  .object({
+    BITBUCKET_USERNAME: z.string().min(1, "BITBUCKET_USERNAME is required"),
+    BITBUCKET_APP_PASSWORD: z.string().min(1, "BITBUCKET_APP_PASSWORD is required"),
+    BITBUCKET_WORKSPACE: z.string().min(1, "BITBUCKET_WORKSPACE is required"),
+    BITBUCKET_BASE_URL: z.string().url().default("https://api.bitbucket.org/2.0"),
+    BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS: z.string().optional(),
+  })
+  .transform((data) => ({
+    BITBUCKET_USERNAME: data.BITBUCKET_USERNAME,
+    BITBUCKET_APP_PASSWORD: data.BITBUCKET_APP_PASSWORD,
+    BITBUCKET_WORKSPACE: data.BITBUCKET_WORKSPACE,
+    BITBUCKET_BASE_URL: data.BITBUCKET_BASE_URL,
+    allowDestructiveTools: parseOptionalBoolEnv(data.BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS),
+  }));
 
 export type Config = z.infer<typeof ConfigSchema>;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,12 +3,17 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { BitbucketClient } from "./client.js";
-import { buildTools, type ToolName } from "./tools/index.js";
+import { buildTools, isGatedDestructiveTool } from "./tools/index.js";
 import type { Config } from "./config.js";
+
+const DESTRUCTIVE_DISABLED_HINT =
+  "Set BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS=true (or 1/yes/on) to enable delete_branch and delete_pr_comment.";
 
 export async function createServer(config: Config) {
   const client = new BitbucketClient(config);
-  const tools = buildTools(client);
+  const tools = config.allowDestructiveTools
+    ? buildTools(client, { allowDestructiveTools: true })
+    : buildTools(client);
 
   const server = new Server(
     { name: "bitbucket-mcp", version: "1.0.0" },
@@ -26,8 +31,18 @@ export async function createServer(config: Config) {
 
   // ── Call tool ───────────────────────────────────────────────────────────────
   server.setRequestHandler(CallToolRequestSchema, async (req) => {
-    const name = req.params.name as ToolName;
-    const tool = tools[name];
+    const name = req.params.name as string;
+
+    if (!config.allowDestructiveTools && isGatedDestructiveTool(name)) {
+      return {
+        content: [
+          { type: "text", text: `Tool "${name}" is disabled. ${DESTRUCTIVE_DISABLED_HINT}` },
+        ],
+        isError: true,
+      };
+    }
+
+    const tool = tools[name as keyof typeof tools];
 
     if (!tool) {
       return {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -3,7 +3,16 @@ import { repositoryTools } from "./repositories.js";
 import { pullRequestTools } from "./pullrequests.js";
 import { branchTools } from "./branches.js";
 
-export function buildTools(client: BitbucketClient) {
+/** Tools that remove refs or comments; omitted from the MCP surface unless `allowDestructiveTools` is true. */
+export const GATED_DESTRUCTIVE_TOOL_NAMES = ["delete_branch", "delete_pr_comment"] as const;
+export type GatedDestructiveToolName = (typeof GATED_DESTRUCTIVE_TOOL_NAMES)[number];
+
+export function isGatedDestructiveTool(name: string): name is GatedDestructiveToolName {
+  return (GATED_DESTRUCTIVE_TOOL_NAMES as readonly string[]).includes(name);
+}
+
+/** Full tool map (all handlers). */
+export function buildAllTools(client: BitbucketClient) {
   return {
     ...repositoryTools(client),
     ...pullRequestTools(client),
@@ -11,5 +20,30 @@ export function buildTools(client: BitbucketClient) {
   };
 }
 
-export type ToolMap = ReturnType<typeof buildTools>;
+export type ToolMap = ReturnType<typeof buildAllTools>;
 export type ToolName = keyof ToolMap;
+
+export type ToolMapWithoutDestructive = Omit<ToolMap, GatedDestructiveToolName>;
+
+/** Full tool map including `delete_branch` and `delete_pr_comment`. */
+export function buildTools(
+  client: BitbucketClient,
+  options: { allowDestructiveTools: true },
+): ToolMap;
+/** Omits destructive delete tools by default (when omitted or false). */
+export function buildTools(
+  client: BitbucketClient,
+  options?: { allowDestructiveTools?: false },
+): ToolMapWithoutDestructive;
+export function buildTools(
+  client: BitbucketClient,
+  options?: { allowDestructiveTools?: boolean },
+): ToolMap | ToolMapWithoutDestructive {
+  const all = buildAllTools(client);
+  if (options?.allowDestructiveTools ?? false) return all;
+  const rest = { ...all };
+  for (const name of GATED_DESTRUCTIVE_TOOL_NAMES) {
+    delete (rest as Record<string, unknown>)[name];
+  }
+  return rest;
+}

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -7,6 +7,7 @@ const sampleConfig: Config = {
   BITBUCKET_APP_PASSWORD: "app-pass",
   BITBUCKET_WORKSPACE: "my-ws",
   BITBUCKET_BASE_URL: "https://api.bitbucket.org/2.0",
+  allowDestructiveTools: false,
 };
 
 describe("BitbucketClient", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -13,6 +13,7 @@ describe("parseConfig", () => {
     if (result.success) {
       expect(result.data.BITBUCKET_WORKSPACE).toBe("ws");
       expect(result.data.BITBUCKET_BASE_URL).toBe("https://api.bitbucket.org/2.0");
+      expect(result.data.allowDestructiveTools).toBe(false);
     }
   });
 
@@ -25,7 +26,29 @@ describe("parseConfig", () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.BITBUCKET_BASE_URL).toBe("https://api.bitbucket.org/2.0");
+      expect(result.data.allowDestructiveTools).toBe(false);
     }
+  });
+
+  it("sets allowDestructiveTools from BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS", () => {
+    for (const v of ["true", "TRUE", "1", "yes", "On"]) {
+      const result = parseConfig({
+        BITBUCKET_USERNAME: "user",
+        BITBUCKET_APP_PASSWORD: "secret",
+        BITBUCKET_WORKSPACE: "ws",
+        BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS: v,
+      });
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.allowDestructiveTools).toBe(true);
+    }
+    const off = parseConfig({
+      BITBUCKET_USERNAME: "user",
+      BITBUCKET_APP_PASSWORD: "secret",
+      BITBUCKET_WORKSPACE: "ws",
+      BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS: "false",
+    });
+    expect(off.success).toBe(true);
+    if (off.success) expect(off.data.allowDestructiveTools).toBe(false);
   });
 
   it("fails when required keys are missing", () => {

--- a/test/pullrequests.test.ts
+++ b/test/pullrequests.test.ts
@@ -268,7 +268,7 @@ describe("pullRequest tools", () => {
   it("delete_pr_comment, resolve_pr_comment, reopen_pr_comment", async () => {
     const del = vi.fn().mockResolvedValue({});
     const post = vi.fn().mockResolvedValue({});
-    const tools = buildTools(mockClient({ delete: del, post }));
+    const tools = buildTools(mockClient({ delete: del, post }), { allowDestructiveTools: true });
     expect(
       await tools.delete_pr_comment.handler({ repo_slug: "r", pr_id: 1, comment_id: 2 }),
     ).toEqual({

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -22,6 +22,7 @@ const baseConfig: Config = {
   BITBUCKET_APP_PASSWORD: "p",
   BITBUCKET_WORKSPACE: "ws",
   BITBUCKET_BASE_URL: "https://api.bitbucket.org/2.0",
+  allowDestructiveTools: false,
 };
 
 /** Collect JSON-RPC responses the server sends back through the transport. */
@@ -89,6 +90,64 @@ describe("createServer", () => {
       | undefined;
     expect(listRes?.result?.tools?.length).toBeGreaterThan(0);
     expect(listRes?.result?.tools?.some((t) => t.name === "list_repositories")).toBe(true);
+    expect(listRes?.result?.tools?.some((t) => t.name === "delete_branch")).toBe(false);
+    expect(listRes?.result?.tools?.some((t) => t.name === "delete_pr_comment")).toBe(false);
+  });
+
+  it("includes delete_branch and delete_pr_comment in tools/list when allowDestructiveTools is true", async () => {
+    const { transport, sent } = createMockTransport();
+    const server = await createServer({ ...baseConfig, allowDestructiveTools: true });
+    await server.connect(transport);
+    const inbound = transport.onmessage!;
+    inbound({
+      jsonrpc: JSONRPC_VERSION,
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: LATEST_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "test-client", version: "0.0.0" },
+      },
+    });
+    await flushResponses();
+    inbound({ jsonrpc: JSONRPC_VERSION, id: 2, method: "tools/list", params: {} });
+    await flushResponses();
+    const listRes = sent.find((m) => isResultForId(m, 2)) as
+      | { result?: { tools?: Array<{ name: string }> } }
+      | undefined;
+    expect(listRes?.result?.tools?.some((t) => t.name === "delete_branch")).toBe(true);
+    expect(listRes?.result?.tools?.some((t) => t.name === "delete_pr_comment")).toBe(true);
+  });
+
+  it("returns disabled error for delete_branch when allowDestructiveTools is false", async () => {
+    const { transport, sent } = createMockTransport();
+    const server = await createServer(baseConfig);
+    await server.connect(transport);
+    const inbound = transport.onmessage!;
+    inbound({
+      jsonrpc: JSONRPC_VERSION,
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: LATEST_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: "t", version: "1" },
+      },
+    });
+    await flushResponses();
+    inbound({
+      jsonrpc: JSONRPC_VERSION,
+      id: 2,
+      method: "tools/call",
+      params: { name: "delete_branch", arguments: { repo_slug: "r", branch_name: "x" } },
+    });
+    await flushResponses();
+    const res = sent.find((m) => isResultForId(m, 2)) as {
+      result?: { isError?: boolean; content?: Array<{ text?: string }> };
+    };
+    expect(res?.result?.isError).toBe(true);
+    expect(res?.result?.content?.[0]?.text).toContain("disabled");
+    expect(res?.result?.content?.[0]?.text).toContain("BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS");
   });
 
   it("returns error for unknown tool name", async () => {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -59,9 +59,16 @@ describe("buildTools", () => {
     expect(get).toHaveBeenCalledWith(expect.stringContaining("q=name+%7E+%22foo%22"));
   });
 
+  it("omits delete_branch and delete_pr_comment when allowDestructiveTools is not set", () => {
+    const tools = buildTools(mockClient({}));
+    expect(tools).not.toHaveProperty("delete_branch");
+    expect(tools).not.toHaveProperty("delete_pr_comment");
+    expect(tools).toHaveProperty("list_repositories");
+  });
+
   it("delete_branch calls DELETE and returns summary", async () => {
     const del = vi.fn().mockResolvedValue({});
-    const tools = buildTools(mockClient({ delete: del }));
+    const tools = buildTools(mockClient({ delete: del }), { allowDestructiveTools: true });
     const out = await tools.delete_branch.handler({ repo_slug: "r1", branch_name: "old" });
     expect(del).toHaveBeenCalledWith("/repositories/ws/r1/refs/branches/old");
     expect(out).toEqual({ deleted: "old", repo: "r1" });


### PR DESCRIPTION
## Summary
delete_branch and delete_pr_comment are no longer registered by default. They only appear in tools/list and run when BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS is set to a truthy value (true, 1, yes, or on, case-insensitive). This reduces accidental data loss from LLM-driven deletes.

## Motivation
Destructive tools were always exposed. Opt-in makes the safer default obvious and requires an explicit operator choice to enable deletes.

## Behavior
- Default (BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS unset or false): delete_branch and delete_pr_comment are omitted from the tool map.
tools/call: If a client still invokes those names while disabled, the server returns an error that explains how to enable them (no API call).
- Unchanged: Other tools, including remove_default_reviewer, unapprove_pull_request, and reopen_pr_comment, stay available.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Chore / maintenance

## Testing
- Config parsing for the new flag (including truthy/falsy strings).
- tools/list excludes gated tools when off, includes them when on.
- tools/call returns a clear “disabled” message for delete_branch when gated off.
- Unit tests for buildTools with and without destructive tools.
