### PR TITLE
docs(readme): clarify bitbucket cloud auth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,54 +2,66 @@
 
 [![npm version](https://img.shields.io/npm/v/@inconcept-labs/bitbucket-mcp.svg)](https://www.npmjs.com/package/@inconcept-labs/bitbucket-mcp)
 
-An [MCP](https://modelcontextprotocol.io) server for [Bitbucket](https://bitbucket.org). It talks to the **Bitbucket Cloud** REST API by default (`https://api.bitbucket.org/2.0`). You can point it at **Bitbucket Server or Data Center** with `BITBUCKET_BASE_URL` if your instance exposes a compatible API; not every endpoint may match Cloud behavior.
+An [MCP](https://modelcontextprotocol.io) server for [Bitbucket Cloud](https://bitbucket.org). Use it from any MCP-capable client (Cursor, Claude Desktop, Codex, and others) to manage pull requests, branches, and repositories in natural language.
 
-Use it from any MCP-capable client (Cursor, Claude Desktop, Codex, and others) to work with pull requests, branches, and repositories in natural language.
+It targets the Bitbucket Cloud REST API at `https://api.bitbucket.org/2.0` by default. You can point it at a Bitbucket Server / Data Center instance with `BITBUCKET_BASE_URL`, but only endpoints that match the Cloud API shape are guaranteed to work.
 
 ## Prerequisites
 
-- **Node.js 24 or newer** (required by this package)
+- **Node.js 24 or newer**
+- A Bitbucket Cloud account with access to the workspace you want to use
 
 ## Installation
 
-Run the published package with `npx` (recommended):
+Run the published package directly with `npx` (recommended — no install step):
 
 ```bash
 npx -y @inconcept-labs/bitbucket-mcp
 ```
 
-Or install globally and run the CLI binary `bitbucket-mcp`:
+Or install globally and run the `bitbucket-mcp` binary:
 
 ```bash
 npm install -g @inconcept-labs/bitbucket-mcp
 bitbucket-mcp
 ```
 
+The server speaks MCP over stdio and is meant to be launched by an MCP client, not run by hand.
+
 ## Setup
 
-### 1. Create a Bitbucket App Password
+### 1. Create an Atlassian API token
 
-1. Go to **Bitbucket → Personal Settings → App Passwords**
-2. Create a new password with these permissions:
-   - **Repositories:** Read, Write (Write needed for `delete_branch`, default reviewers)
-   - **Pull Requests:** Read, Write
-3. Copy the generated password
+This server authenticates with a scoped Atlassian **API token**. (Bitbucket Cloud app passwords are deprecated — new ones can no longer be created since 2025-09-09, and any remaining ones stop working on 2026-06-09.)
 
-Keep app passwords out of source control. Put them only in your MCP client’s `env` block or in a local environment that is not committed.
+1. Sign in to Bitbucket, click your avatar (top-right) → **Account settings**.
+2. Open the **Security** tab → **Create and manage API tokens** → **Create API token with scopes**.
+3. Give the token a name and an expiry date, then select **Bitbucket** as the app.
+4. Select these scopes:
+   - `read:repository:bitbucket`
+   - `write:repository:bitbucket`
+   - `read:pullrequest:bitbucket`
+   - `write:pullrequest:bitbucket`
+5. Click **Create token** and copy the value immediately — Atlassian only displays it once.
 
-### 2. Environment variables
+### 2. Find your workspace slug and Atlassian email
 
-| Variable                                | Required | Description                                                                                                                                                      |
-| --------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `BITBUCKET_USERNAME`                    | Yes      | Your Bitbucket username                                                                                                                                          |
-| `BITBUCKET_APP_PASSWORD`                | Yes      | App password from step 1                                                                                                                                         |
-| `BITBUCKET_WORKSPACE`                   | Yes      | Workspace slug (from your Bitbucket URL)                                                                                                                         |
-| `BITBUCKET_BASE_URL`                    | No       | API base URL (default: `https://api.bitbucket.org/2.0`). Use for Server/DC.                                                                                      |
-| `BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS` | No       | Set to `true`, `1`, `yes`, or `on` to register **`delete_branch`** and **`delete_pr_comment`**. Off by default so those tools are not exposed unless you opt in. |
+- **Workspace slug:** the path segment in your Bitbucket URL — e.g. for `https://bitbucket.org/acme-inc/some-repo`, the slug is `acme-inc`. Use the slug, not the workspace display name.
+- **Atlassian email:** the email address you sign in to Atlassian with. API tokens authenticate as `email:token` — your Bitbucket username will _not_ work.
 
-### 3. MCP client configuration
+### 3. Environment variables
 
-Add a server entry that runs `npx` with the scoped package and passes the variables above. Example:
+| Variable                                | Required | Description                                                                                                                                              |
+| --------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BITBUCKET_USERNAME`                    | Yes      | Your **Atlassian account email** (used as the Basic-auth username paired with the API token).                                                            |
+| `BITBUCKET_APP_PASSWORD`                | Yes      | Your **Atlassian API token** from step 1. The variable is named `APP_PASSWORD` for backward compatibility.                                               |
+| `BITBUCKET_WORKSPACE`                   | Yes      | Workspace slug from your Bitbucket URL.                                                                                                                  |
+| `BITBUCKET_BASE_URL`                    | No       | API base URL. Defaults to `https://api.bitbucket.org/2.0`. Override only for Bitbucket Server / Data Center.                                             |
+| `BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS` | No       | Set to `true`, `1`, `yes`, or `on` to expose `delete_branch` and `delete_pr_comment`. Off by default — these tools are not registered unless you opt in. |
+
+### 4. MCP client configuration
+
+Add a server entry that runs the package with `npx` and passes the variables above. Example:
 
 ```json
 {
@@ -58,64 +70,64 @@ Add a server entry that runs `npx` with the scoped package and passes the variab
       "command": "npx",
       "args": ["-y", "@inconcept-labs/bitbucket-mcp"],
       "env": {
-        "BITBUCKET_USERNAME": "your_username",
-        "BITBUCKET_APP_PASSWORD": "your_app_password",
-        "BITBUCKET_WORKSPACE": "your_workspace"
+        "BITBUCKET_USERNAME": "you@example.com",
+        "BITBUCKET_APP_PASSWORD": "your_atlassian_api_token",
+        "BITBUCKET_WORKSPACE": "your_workspace_slug"
       }
     }
   }
 }
 ```
 
-**Where to put this**
+**Where this file lives**
 
 - **Cursor:** `~/.cursor/mcp.json`, or **Cursor → Settings → MCP**
 - **Claude Desktop (macOS):** `~/Library/Application Support/Claude/claude_desktop_config.json`
 - **Claude Desktop (Windows):** `%APPDATA%\Claude\claude_desktop_config.json`
 
-Merge the `bitbucket` block into the existing `mcpServers` object if you already have other servers configured.
+After saving, restart the MCP client so it picks up the new server.
 
 ## Available tools
 
 ### Repositories
 
-| Tool                | Description                                                |
-| ------------------- | ---------------------------------------------------------- |
-| `list_repositories` | List repos in the workspace (supports search & pagination) |
+| Tool                | Description                                                 |
+| ------------------- | ----------------------------------------------------------- |
+| `list_repositories` | List repos in the workspace (supports search & pagination). |
 
 ### Pull requests
 
-| Tool                      | Description                                                         |
-| ------------------------- | ------------------------------------------------------------------- |
-| `list_pull_requests`      | List PRs filtered by state (OPEN / MERGED / DECLINED / SUPERSEDED)  |
-| `get_pull_request`        | Full PR details including participants and reviewers                |
-| `create_pull_request`     | Open a new PR with optional reviewers                               |
-| `update_pull_request`     | Update title, description, or reviewers                             |
-| `merge_pull_request`      | Merge using merge_commit, squash, or fast_forward                   |
-| `decline_pull_request`    | Decline a PR with an optional message                               |
-| `add_pr_comment`          | Post a Markdown comment on a PR                                     |
-| `get_diff`                | Fetch the unified diff (truncated to 8 KB)                          |
-| `list_pr_comments`        | List all comments on a PR                                           |
-| `get_pr_comment`          | Get a specific comment                                              |
-| `update_pr_comment`       | Update a comment                                                    |
-| `delete_pr_comment`       | Delete a comment (requires `BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS`) |
-| `resolve_pr_comment`      | Resolve a comment thread                                            |
-| `reopen_pr_comment`       | Reopen a resolved comment thread                                    |
-| `approve_pull_request`    | Approve a PR                                                        |
-| `unapprove_pull_request`  | Remove your approval                                                |
-| `request_pr_changes`      | Request changes on a PR                                             |
-| `list_pr_statuses`        | List commit/build statuses for a PR                                 |
-| `list_default_reviewers`  | List default reviewers (auto-added to new PRs)                      |
-| `get_default_reviewer`    | Get a specific default reviewer                                     |
-| `add_default_reviewer`    | Add a user as default reviewer                                      |
-| `remove_default_reviewer` | Remove a user from default reviewers                                |
+| Tool                      | Description                                                                 |
+| ------------------------- | --------------------------------------------------------------------------- |
+| `list_pull_requests`      | List PRs filtered by state (`OPEN` / `MERGED` / `DECLINED` / `SUPERSEDED`). |
+| `get_pull_request`        | Full PR details including participants and reviewers.                       |
+| `create_pull_request`     | Open a new PR with optional reviewers.                                      |
+| `update_pull_request`     | Update title, description, or reviewers.                                    |
+| `merge_pull_request`      | Merge using `merge_commit`, `squash`, or `fast_forward`.                    |
+| `decline_pull_request`    | Decline a PR with an optional message.                                      |
+| `add_pr_comment`          | Post a Markdown comment on a PR.                                            |
+| `get_diff`                | Fetch the unified diff (truncated for safety).                              |
+| `list_pr_comments`        | List all comments on a PR.                                                  |
+| `get_pr_comment`          | Get a specific comment.                                                     |
+| `update_pr_comment`       | Update a comment.                                                           |
+| `delete_pr_comment`       | Delete a comment (requires `BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS`).        |
+| `resolve_pr_comment`      | Resolve a comment thread.                                                   |
+| `reopen_pr_comment`       | Reopen a resolved comment thread.                                           |
+| `approve_pull_request`    | Approve a PR.                                                               |
+| `unapprove_pull_request`  | Remove your approval.                                                       |
+| `request_pr_changes`      | Request changes on a PR.                                                    |
+| `list_pr_statuses`        | List commit / build statuses for a PR.                                      |
+| `list_default_reviewers`  | List default reviewers (auto-added to new PRs).                             |
+| `get_default_reviewer`    | Get a specific default reviewer.                                            |
+| `add_default_reviewer`    | Add a user as default reviewer.                                             |
+| `remove_default_reviewer` | Remove a user from default reviewers.                                       |
 
 ### Branches
 
-| Tool            | Description                                                        |
-| --------------- | ------------------------------------------------------------------ |
-| `list_branches` | List branches with optional name search                            |
-| `delete_branch` | Delete a branch (requires `BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS`) |
+| Tool            | Description                                                         |
+| --------------- | ------------------------------------------------------------------- |
+| `list_branches` | List branches with optional name search.                            |
+| `delete_branch` | Delete a branch (requires `BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS`). |
 
 ## Example prompts
 
@@ -128,23 +140,23 @@ Merge the `bitbucket` block into the existing `mcpServers` object if you already
 
 ## Troubleshooting
 
-- **Configuration error on startup** — One or more required env vars are missing or empty. Set `BITBUCKET_USERNAME`, `BITBUCKET_APP_PASSWORD`, and `BITBUCKET_WORKSPACE`, then restart the MCP client.
-- **401 / 403 from Bitbucket** — Wrong username or app password, or the app password lacks the scopes listed above. Regenerate the app password if needed.
-- **404 or “not found” for repos** — Check `BITBUCKET_WORKSPACE` matches the workspace **slug** in the URL (not the display name).
-
-## Testing
-
-Pull request CI runs **ESLint → Prettier → unit tests (`npm test`) → build (`npm run build`) → MCP stdio integration tests (`npm run test:integration`)**. Integration tests need the compiled `dist/` output. For local commands, see [CONTRIBUTING.md](CONTRIBUTING.md).
+- **`Configuration error` on startup** — One or more required env vars are missing or empty. Set `BITBUCKET_USERNAME`, `BITBUCKET_APP_PASSWORD`, and `BITBUCKET_WORKSPACE`, then restart the MCP client.
+- **`401 Unauthorized`** — Most often one of:
+  - `BITBUCKET_USERNAME` is your Bitbucket username instead of your **Atlassian email** — API tokens require the email.
+  - The API token is wrong, expired, or was created without the scopes listed above.
+  - You're still using a legacy app password — create an API token instead (app passwords are being phased out).
+- **`403 Forbidden`** — The token authenticates but is missing a scope for the tool you ran. Re-create the token and add the missing scope (e.g. `write:pullrequest:bitbucket` for merge/approve, `write:repository:bitbucket` for `delete_branch`).
+- **`404 Not Found` for repos** — `BITBUCKET_WORKSPACE` is wrong. Use the **slug** from the URL (e.g. `acme-inc`), not the workspace display name.
+- **Destructive tool not found** — `delete_branch` and `delete_pr_comment` are not registered unless `BITBUCKET_MCP_ALLOW_DESTRUCTIVE_TOOLS` is set to a truthy value. Set it and restart the client.
 
 ## Contributing
 
-For development, project layout, and release automation, see [CONTRIBUTING.md](CONTRIBUTING.md).
+For development, project layout, testing, and release automation, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Links
 
-- [Package on npm](https://www.npmjs.com/package/@inconcept-labs/bitbucket-mcp)
-- [Issues](https://github.com/inconcept/bitbucket-mcp/issues)
-- [Repository](https://github.com/inconcept/bitbucket-mcp)
+- [Atlassian: Create an API token](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/)
+- [Atlassian: API token permissions](https://support.atlassian.com/bitbucket-cloud/docs/api-token-permissions/)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This server authenticates with a scoped Atlassian **API token**. (Bitbucket Clou
    - `write:repository:bitbucket`
    - `read:pullrequest:bitbucket`
    - `write:pullrequest:bitbucket`
+   - `admin:repository:bitbucket`
 5. Click **Create token** and copy the value immediately — Atlassian only displays it once.
 
 ### 2. Find your workspace slug and Atlassian email


### PR DESCRIPTION
This PR updates the README.md to make Bitbucket Cloud setup clearer and reduce common onboarding errors.
- Reframes auth around Atlassian API tokens (and explains app password deprecation timing).
- Clarifies required env vars, especially that BITBUCKET_USERNAME should be the Atlassian email.
- Improves setup flow with clearer steps for token creation, workspace slug identification, and MCP config.
- Refreshes tool descriptions and troubleshooting for common 401, 403, and workspace slug issues.
- Adds links to Atlassian docs for token creation and permissions.

## Why
Users were likely to hit auth/config issues due to older app-password language and ambiguous variable descriptions. This change makes first-time setup more reliable and shortens time-to-fix when errors happen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the server targets Bitbucket Cloud and adjusted platform/prerequisite language
  * Replaced app-password guidance with Atlassian API token instructions and updated auth/setup steps
  * Emphasized running via npx or global binary and that the server is launched by an MCP client
  * Updated tools table/descriptions and tightened troubleshooting guidance; removed legacy testing and external link references
<!-- end of auto-generated comment: release notes by coderabbit.ai -->