### PR TITLE
feat(merge): honor repo default merge strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues for `inconcept/bitbucket-mcp` (uses the `gh` CLI). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default canonical labels — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/adr/0001-merge-strategy-resolution.md
+++ b/docs/adr/0001-merge-strategy-resolution.md
@@ -1,0 +1,13 @@
+# Resolve repo default merge strategy via the PR object
+
+When `merge_pull_request` is called without an explicit `merge_strategy`, we GET the pull request and use `destination.branch.default_merge_strategy` (falling back to `merge_commit` if absent).
+
+Two non-obvious Bitbucket Cloud API facts drove this:
+
+1. **The merge endpoint hardcodes `merge_commit` when `merge_strategy` is omitted.** The body schema declares `"default": "merge_commit"`. Omitting the field does NOT make Bitbucket honor the repository's configured default — so we must resolve it client-side.
+2. **The resolved default is exposed directly on the PR object.** `PullRequest.destination.branch.default_merge_strategy` already reflects the repo's configured default for that destination branch (Bitbucket performs prefix-matching against the branching model server-side). The `branching-model/settings` endpoint does not expose merge strategy fields per its public spec, so replicating resolution client-side would be both redundant and incomplete.
+
+## Considered options
+
+- **Omit `merge_strategy` and let the server default**: rejected — server defaults to hardcoded `merge_commit`, ignoring repo config.
+- **Fetch `branching-model/settings` and do prefix-matching client-side**: rejected — the public spec doesn't expose merge strategy fields on that resource, and the PR object already carries the resolved value.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/src/tools/pullrequests/merge-pull-request.ts
+++ b/src/tools/pullrequests/merge-pull-request.ts
@@ -32,8 +32,8 @@ export class MergePullRequestTool extends BitbucketMcpTool<typeof mergePullReque
   async execute(client: BitbucketClient, args: z.infer<typeof mergePullRequestSchema>) {
     const base = prPath(client.workspace, args.repo_slug, args.pr_id);
 
-    let strategy: string = args.merge_strategy ?? "";
-    if (!strategy) {
+    let strategy: string | undefined = args.merge_strategy;
+    if (strategy === undefined) {
       const pr = await client.get<BbPullRequest>(base);
       strategy = pr.destination?.branch?.default_merge_strategy ?? FALLBACK_STRATEGY;
     }

--- a/src/tools/pullrequests/merge-pull-request.ts
+++ b/src/tools/pullrequests/merge-pull-request.ts
@@ -4,28 +4,45 @@ import type { BbPullRequest } from "../../types.js";
 import { BitbucketMcpTool } from "../bitbucket-mcp-tool.js";
 import { RepoArg, PrIdArg, MsgArg, prPath } from "./common.js";
 
+const MERGE_STRATEGIES = [
+  "merge_commit",
+  "squash",
+  "fast_forward",
+  "squash_fast_forward",
+  "rebase_fast_forward",
+  "rebase_merge",
+] as const;
+
+const FALLBACK_STRATEGY: (typeof MERGE_STRATEGIES)[number] = "merge_commit";
+
 const mergePullRequestSchema = z.object({
   repo_slug: RepoArg,
   pr_id: PrIdArg,
-  merge_strategy: z.enum(["merge_commit", "squash", "fast_forward"]).default("merge_commit"),
+  merge_strategy: z.enum(MERGE_STRATEGIES).optional(),
   message: MsgArg,
   close_source_branch: z.boolean().optional(),
 });
 
 export class MergePullRequestTool extends BitbucketMcpTool<typeof mergePullRequestSchema> {
   readonly toolName = "merge_pull_request" as const;
-  readonly description = "Merge an open pull request";
+  readonly description =
+    "Merge an open pull request. When merge_strategy is omitted, the repository's configured default for the PR's destination branch is used (falling back to merge_commit if none is set).";
   readonly schema = mergePullRequestSchema;
 
   async execute(client: BitbucketClient, args: z.infer<typeof mergePullRequestSchema>) {
-    const body: Record<string, unknown> = { merge_strategy: args.merge_strategy };
+    const base = prPath(client.workspace, args.repo_slug, args.pr_id);
+
+    let strategy: string = args.merge_strategy ?? "";
+    if (!strategy) {
+      const pr = await client.get<BbPullRequest>(base);
+      strategy = pr.destination?.branch?.default_merge_strategy ?? FALLBACK_STRATEGY;
+    }
+
+    const body: Record<string, unknown> = { merge_strategy: strategy };
     if (args.message) body.message = args.message;
     if (args.close_source_branch !== undefined) body.close_source_branch = args.close_source_branch;
 
-    const result = await client.post<BbPullRequest>(
-      `${prPath(client.workspace, args.repo_slug, args.pr_id)}/merge`,
-      body,
-    );
-    return { merged: true, state: result.state };
+    const result = await client.post<BbPullRequest>(`${base}/merge`, body);
+    return { merged: true, state: result.state, merge_strategy: strategy };
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,8 @@ export interface BbUser {
 export interface BbBranch {
   name: string;
   target: { hash: string; date?: string };
+  merge_strategies?: string[];
+  default_merge_strategy?: string;
 }
 
 export interface BbPullRequest {

--- a/test/pullrequests.test.ts
+++ b/test/pullrequests.test.ts
@@ -147,12 +147,13 @@ describe("pullRequest tools", () => {
       message: "merge msg",
       close_source_branch: true,
     });
-    expect(out).toEqual({ merged: true, state: "MERGED" });
+    expect(out).toEqual({ merged: true, state: "MERGED", merge_strategy: "squash" });
   });
 
   it("merge_pull_request sends only merge_strategy when no message or close_source_branch", async () => {
     const post = vi.fn().mockResolvedValue(prFixture({ state: "MERGED" }));
-    const tools = buildTools(mockClient({ post }));
+    const get = vi.fn();
+    const tools = buildTools(mockClient({ post, get }));
     await tools.merge_pull_request.handler({
       repo_slug: "r",
       pr_id: 2,
@@ -161,6 +162,64 @@ describe("pullRequest tools", () => {
     expect(post).toHaveBeenCalledWith("/repositories/ws/r/pullrequests/2/merge", {
       merge_strategy: "fast_forward",
     });
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it("merge_pull_request resolves repo default when merge_strategy is omitted", async () => {
+    const get = vi.fn().mockResolvedValue(
+      prFixture({
+        destination: {
+          branch: {
+            name: "main",
+            target: { hash: "h" },
+            default_merge_strategy: "rebase_merge",
+          },
+        },
+      }),
+    );
+    const post = vi.fn().mockResolvedValue(prFixture({ state: "MERGED" }));
+    const tools = buildTools(mockClient({ get, post }));
+    const out = await tools.merge_pull_request.handler({ repo_slug: "r", pr_id: 8 });
+    expect(get).toHaveBeenCalledWith("/repositories/ws/r/pullrequests/8");
+    expect(post).toHaveBeenCalledWith("/repositories/ws/r/pullrequests/8/merge", {
+      merge_strategy: "rebase_merge",
+    });
+    expect(out).toEqual({ merged: true, state: "MERGED", merge_strategy: "rebase_merge" });
+  });
+
+  it("merge_pull_request falls back to merge_commit when default is missing", async () => {
+    const get = vi.fn().mockResolvedValue(prFixture());
+    const post = vi.fn().mockResolvedValue(prFixture({ state: "MERGED" }));
+    const tools = buildTools(mockClient({ get, post }));
+    const out = await tools.merge_pull_request.handler({ repo_slug: "r", pr_id: 9 });
+    expect(get).toHaveBeenCalledWith("/repositories/ws/r/pullrequests/9");
+    expect(post).toHaveBeenCalledWith("/repositories/ws/r/pullrequests/9/merge", {
+      merge_strategy: "merge_commit",
+    });
+    expect(out.merge_strategy).toBe("merge_commit");
+  });
+
+  it("merge_pull_request accepts all six bitbucket merge strategies", async () => {
+    const post = vi.fn().mockResolvedValue(prFixture({ state: "MERGED" }));
+    const get = vi.fn();
+    const tools = buildTools(mockClient({ post, get }));
+    const strategies = [
+      "merge_commit",
+      "squash",
+      "fast_forward",
+      "squash_fast_forward",
+      "rebase_fast_forward",
+      "rebase_merge",
+    ] as const;
+    for (const strategy of strategies) {
+      const out = await tools.merge_pull_request.handler({
+        repo_slug: "r",
+        pr_id: 1,
+        merge_strategy: strategy,
+      });
+      expect(out.merge_strategy).toBe(strategy);
+    }
+    expect(get).not.toHaveBeenCalled();
   });
 
   it("decline_pull_request posts message or empty object", async () => {

--- a/test/tools/all-tool-classes.test.ts
+++ b/test/tools/all-tool-classes.test.ts
@@ -142,6 +142,7 @@ const TOOL_CASES: ToolCase[] = [
     Tool: MergePullRequestTool,
     args: { repo_slug: "r", pr_id: 1 },
     prepare: (c) => {
+      vi.mocked(c.get).mockResolvedValue(minimalPr());
       vi.mocked(c.post).mockResolvedValue(minimalPr({ state: "MERGED" }));
     },
   },


### PR DESCRIPTION
Closes #33.

## Summary
- `merge_pull_request` now resolves the repository's configured default merge strategy when `merge_strategy` is omitted, by reading `destination.branch.default_merge_strategy` off the PR (falls back to `merge_commit`).
- Schema accepts all six Bitbucket strategies; explicit caller input still wins and skips the extra GET.
- Response echoes the strategy actually sent.

See `docs/adr/0001-merge-strategy-resolution.md` for rationale.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (new cases: explicit → no GET; omitted → GET + uses default; omitted + missing default → `merge_commit`; all six strategies accepted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added agent operation guidelines and domain documentation for AI-powered workflows
  * Added Architecture Decision Record documenting merge strategy resolution behavior

* **Improvements**
  * Pull request merge tool now automatically resolves merge strategy from the destination branch's default configuration when not explicitly specified

<!-- end of auto-generated comment: release notes by coderabbit.ai -->